### PR TITLE
add self consumption sales

### DIFF
--- a/retrieve_info_from_DB.py
+++ b/retrieve_info_from_DB.py
@@ -23,58 +23,73 @@ def retrieve_calls_info(conn):
 def retrieve_sales_info(conn):
 
     electr_sales = pd.read_sql("""
-        SELECT con.contract_id, con.cups, tar.tariff_name as tariff, con.product_ekon_id as product, 
-        con.sales_company_id, sls.sales_company_name, sls.channel_group, 
-        'LIGHT' as business_type, date(co_start_date) as contract_start_date, esup.sp_zipcode as zipcode, 
-        prov.province  FROM CON_ECONTRACT_DIM con
+        SELECT con.contract_id, 
+        con.cups, 
+        tar.tariff_name as tariff, 
+        con.product_ekon_id as product, 
+        con.sales_company_id, 
+        sls.sales_company_name, 
+        sls.channel_group, 
+        'LIGHT' as business_type, 
+        date(co_start_date) as contract_start_date, 
+        esup.sp_zipcode as zipcode, 
+        prov.province  
+        FROM CON_ECONTRACT_DIM con
         left JOIN CON_TARIFF_DIM tar on con.tariff_ekon_id = tar.tariff_ekon_id 
         left join SLS_COMPANY_DIM sls on con.sales_company_id = sls.sales_company_id 
         left join CON_STATUS_DIM sta on con.co_status_id = sta.status_pk 
         left join CON_ESUPPLY_POINT_DIM esup on esup.contract_id = con.contract_id
         left join GEN_PROVINCE_DIM prov on left(esup.sp_zipcode, 2) = prov.province_nk
-        left join OPE_SALES ope on con.contract_id = ope.contract_id
+        /*left join OPE_SALES ope on con.contract_id = ope.contract_id*/
         WHERE registration_type IN('Cambio', 'Nueva Alta')
         /*and ope.contract_id is null*/
-        and esup.sp_zipcode is not null
-
+        /*and esup.sp_zipcode is not null*/
         """, conn)
 
     gas_sales = pd.read_sql("""
-        SELECT con.contract_id, con.cups, tar.tariff_name as tariff, tar.tariff_name as product, 
-        COALESCE(con.sales_company_id, 9997) AS sales_company_id, sls.sales_company_name, sls.channel_group, 
-        'GAS' as business_type, date(co_start_date) as contract_start_date, esup.sp_zipcode as zipcode, 
-        prov.province  FROM CON_GCONTRACT_DIM con
+        SELECT con.contract_id, 
+        con.cups, 
+        tar.tariff_name as tariff, 
+        tar.tariff_name as product, 
+        COALESCE(con.sales_company_id, 9997) AS sales_company_id, 
+        sls.sales_company_name, 
+        sls.channel_group, 
+        'GAS' as business_type, 
+        date(co_start_date) as contract_start_date, 
+        esup.sp_zipcode as zipcode, 
+        prov.province  
+        FROM CON_GCONTRACT_DIM con
         left JOIN CON_TARIFF_DIM tar on con.tariff_id = tar.tariff_pk
         left join SLS_COMPANY_DIM sls on COALESCE(con.sales_company_id, 9997) = sls.sales_company_id 
         left join CON_STATUS_DIM sta on con.co_status_id = sta.status_pk 
         left join CON_GSUPPLY_POINT_DIM esup on esup.contract_id = con.contract_id
         left join GEN_PROVINCE_DIM prov on left(esup.sp_zipcode, 2) = prov.province_nk
-        LEFT JOIN OPE_SALES ope on ope.contract_id = con.contract_id
+       /*LEFT JOIN OPE_SALES ope on ope.contract_id = con.contract_id*/
         WHERE new_client_flag = 1
         /*and ope.contract_id is null*/
-        and esup.sp_zipcode is not null
+        /*and esup.sp_zipcode is not null*/
 
         """, conn)
 
     self_consumption_sales = pd.read_sql("""
         select potential_id as contract_id,
-        COALESCE(date(A.co_start_date), B.co_start_date) as contract_start_date, 
         A.cups, 
         B.tariff_ekon_id as tariff, 
-        A.type as product, 
+        A.product as product, 
         B.sales_company_id, 
         C.sales_company_name,
         C.channel_group, 
         'SELF-CONSUMPTION' AS business_type, 
+        A.co_start_date as contract_start_date, 
         sp_zipcode as zipcode, 
         province_ekon_name as province 
-        from STAGING.SLS_SELFCONSUMPTION_DAT A
+        from SLS_SELF_CONSUMPTION A
         LEFT JOIN
         (WITH CONTRACTS AS( 
         SELECT contract_id, cups, date(co_start_date) as co_start_date, registration_type, tariff_ekon_id, sales_company_id,
         RANK() OVER(
         PARTITION BY(cups)
-        order by co_start_date desc
+        order by co_start_date desc, contract_id desc
         ) as ranking
         FROM CON_ECONTRACT_DIM 
         WHERE registration_type IN('Cambio','Nueva Alta'))
@@ -82,8 +97,7 @@ def retrieve_sales_info(conn):
         WHERE ranking = 1) B ON A.cups = B.cups 
         left JOIN SLS_COMPANY_DIM C on B.sales_company_id = C.sales_company_id 
         left join CON_ESUPPLY_POINT_DIM D ON B.contract_id = D.contract_id
-        left JOIN GEN_PROVINCE_DIM E ON left(sp_zipcode, 2) = province_nk
-        /*LEFT JOIN OPE_SALES ope on ope.contract_id = A.contract_id*/""", conn)
+        left JOIN GEN_PROVINCE_DIM E ON left(sp_zipcode, 2) = province_nk""", conn)
 
     sales = electr_sales.append(gas_sales).append(self_consumption_sales)
 


### PR DESCRIPTION
He cambiado las queries para añadir las ventas de autoconsumo.
Para el resto de ventas se carga toda la tabla, para que luego se compare con la info existente y solo inserte la información que sea nueva.
He establecido el contract_id com a primary key en OPE_SALES.
